### PR TITLE
Reduce alloc

### DIFF
--- a/BulletSharp/BulletSharp.csproj
+++ b/BulletSharp/BulletSharp.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Native.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="NonZeroIntPtr.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SoftBody\AlignedAnchorArray.cs" />
     <Compile Include="SoftBody\AlignedJointArray.cs" />

--- a/BulletSharp/Collision/CollisionObjectWrapper.cs
+++ b/BulletSharp/Collision/CollisionObjectWrapper.cs
@@ -4,11 +4,12 @@ using static BulletSharp.UnsafeNativeMethods;
 
 namespace BulletSharp
 {
-	public class CollisionObjectWrapper : BulletObject
+	public struct CollisionObjectWrapper
 	{
+		internal NonZeroIntPtr Native;
 		internal CollisionObjectWrapper(IntPtr native)
 		{
-			Initialize(native);
+			Native = native;
 		}
 
 		public CollisionObject CollisionObject

--- a/BulletSharp/Collision/PersistentManifold.cs
+++ b/BulletSharp/Collision/PersistentManifold.cs
@@ -31,7 +31,10 @@ namespace BulletSharp
 
 		private static bool ContactProcessedUnmanaged(IntPtr cp, IntPtr body0, IntPtr body1)
 		{
-			_contactProcessed.Invoke(new ManifoldPoint(cp), CollisionObject.GetManaged(body0), CollisionObject.GetManaged(body1));
+			using (ManifoldPoint p = new ManifoldPoint(cp))
+			{
+				_contactProcessed.Invoke(p, CollisionObject.GetManaged(body0), CollisionObject.GetManaged(body1));
+			}
 			return false;
 		}
 

--- a/BulletSharp/NonZeroIntPtr.cs
+++ b/BulletSharp/NonZeroIntPtr.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace BulletSharp
+{
+	/// <summary>
+	/// Struct will throw exception when assigning or accessing zero'ed pointer
+	/// </summary>
+	public struct NonZeroIntPtr
+	{
+		IntPtr ptr;
+
+		/// <summary>
+		/// Assign the following IntPtr to this struct
+		/// </summary>
+		/// <param name="ptrParam">The value to pass over</param>
+		/// <param name="testZeroed">Should we throw if the pointed is zero'ed</param>
+		public NonZeroIntPtr(IntPtr ptrParam)
+		{
+			if (ptrParam == IntPtr.Zero)
+				throw new ArgumentNullException(nameof(ptrParam));
+			ptr = ptrParam;
+		}
+
+		/// <summary>
+		/// Same as implicit casting
+		/// </summary>
+		public IntPtr Pointer
+		{
+			get{ return this; }
+		}
+
+		/// <summary>
+		/// Is the pointer zero'ed, doesn't throw
+		/// </summary>
+		public bool IsZero()
+		{
+			return ptr == IntPtr.Zero;
+		}
+
+		public static implicit operator NonZeroIntPtr(IntPtr v)
+		{
+			return new NonZeroIntPtr(v);
+		}
+
+		public static implicit operator IntPtr(NonZeroIntPtr v)
+		{
+			return v.ptr == IntPtr.Zero ? throw new ArgumentNullException("Pointer") : v.ptr;
+		}
+		
+		/// <summary>
+		/// Return false if the pointer is zeroed, outputs the pointer and set the pointer inside this one to zero
+		/// </summary>
+		public bool Clear( out IntPtr intPtr )
+		{
+			intPtr = ptr;
+			ptr = IntPtr.Zero;
+			return IsZero() == false;
+		}
+	}
+}

--- a/BulletSharp/test/Program.cs
+++ b/BulletSharp/test/Program.cs
@@ -353,12 +353,16 @@ namespace BulletSharpTest
 
         public override float AddSingleResult(LocalRayResult rayResult, bool normalInWorldSpace)
         {
-            if (rayResult.LocalShapeInfo != null)
-            {
-                Success = true;
-                TriangleIndex = rayResult.LocalShapeInfo.TriangleIndex;
-            }
-            return base.AddSingleResult(rayResult, normalInWorldSpace);
+			try
+			{
+				TriangleIndex = rayResult.LocalShapeInfo.TriangleIndex;
+				Success = true;
+			}
+			catch(Exception e)
+			{
+				Success = false;
+			}
+			return base.AddSingleResult(rayResult, normalInWorldSpace);
         }
     }
 }


### PR DESCRIPTION
**Description**
This PR changes a couple of data types to structs to reduces the amount of garbage generated, as those types only communicate with the C++ layer they should be safe to replace with lightweight structs.
**Changes**
The types changed are : CollisionObjectWrapper, ManifoldPoint, LocalConvexResult, LocalRayResult and LocalShapeInfo. 
I have also introduced a new type called 'NonZeroIntPtr' which helps in filling the features that where included with the implementation of those classes but cannot be ported to structs.

---

I need some clarifications though
 - Would [this line](https://github.com/Eideren/BulletSharpPInvoke/blob/bcc9220f302376307983eafe8ce326dab6292750/BulletSharp/Collision/PersistentManifold.cs#L204) dispose of the data created from [this one](https://github.com/Eideren/BulletSharpPInvoke/blob/bcc9220f302376307983eafe8ce326dab6292750/BulletSharp/Collision/PersistentManifold.cs#L127) with this PR ?
 - What is BulletObjectTracker's use, it just register classes into an hashset and removes them from it on dispose, so it's only there to avoid them being collected by the GC, right or am I missing something ?

---

The second commit updates the syntax used within /test, **I couldn't quite get it to run to validate this PR though**. If you really can't find the time to test this out I'll try to figure it out on my own.