### PR TITLE
Enumerator changes

### DIFF
--- a/BulletSharp/Collision/DbvtArray.cs
+++ b/BulletSharp/Collision/DbvtArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public Dbvt Current => _array[_i];

--- a/BulletSharp/Collision/DbvtArray.cs
+++ b/BulletSharp/Collision/DbvtArray.cs
@@ -5,7 +5,7 @@ using static BulletSharp.UnsafeNativeMethods;
 
 namespace BulletSharp
 {
-	public class DbvtArrayEnumerator : IEnumerator<Dbvt>
+	public struct DbvtArrayEnumerator : IEnumerator<Dbvt>
 	{
 		private int _i;
 		private int _count;
@@ -92,7 +92,12 @@ namespace BulletSharp
 			}
 		}
 
-		public IEnumerator<Dbvt> GetEnumerator()
+		public DbvtArrayEnumerator GetEnumerator()
+		{
+			return new DbvtArrayEnumerator(this);
+		}
+
+		IEnumerator<Dbvt> IEnumerable<Dbvt>.GetEnumerator()
 		{
 			return new DbvtArrayEnumerator(this);
 		}

--- a/BulletSharp/Collision/DbvtNodePtrArray.cs
+++ b/BulletSharp/Collision/DbvtNodePtrArray.cs
@@ -5,7 +5,7 @@ using static BulletSharp.UnsafeNativeMethods;
 
 namespace BulletSharp
 {
-	public class DbvtNodePtrArrayEnumerator : IEnumerator<DbvtNode>
+	public struct DbvtNodePtrArrayEnumerator : IEnumerator<DbvtNode>
 	{
 		private int _i;
 		private int _count;
@@ -92,7 +92,12 @@ namespace BulletSharp
 			}
 		}
 
-		public IEnumerator<DbvtNode> GetEnumerator()
+		public DbvtNodePtrArrayEnumerator GetEnumerator()
+		{
+			return new DbvtNodePtrArrayEnumerator(this);
+		}
+
+		IEnumerator<DbvtNode> IEnumerable<DbvtNode>.GetEnumerator()
 		{
 			return new DbvtNodePtrArrayEnumerator(this);
 		}

--- a/BulletSharp/Collision/DbvtNodePtrArray.cs
+++ b/BulletSharp/Collision/DbvtNodePtrArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public DbvtNode Current => _array[_i];

--- a/BulletSharp/Common/GenericListEnumerator.cs
+++ b/BulletSharp/Common/GenericListEnumerator.cs
@@ -28,7 +28,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public void Dispose()

--- a/BulletSharp/Common/GenericListEnumerator.cs
+++ b/BulletSharp/Common/GenericListEnumerator.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace BulletSharp
 {
-	public sealed class GenericListEnumerator<T> : IEnumerator<T>
+	public struct GenericListEnumerator<T> : IEnumerator<T>
 	{
 		private int _i;
 		private readonly int _count;

--- a/BulletSharp/LinearMath/AlignedBroadphasePairArray.cs
+++ b/BulletSharp/LinearMath/AlignedBroadphasePairArray.cs
@@ -29,9 +29,9 @@ namespace BulletSharp
 		}
 	}
 
-	public class AlignedBroadphasePairArrayEnumerator : IEnumerator<BroadphasePair>
+	public struct AlignedBroadphasePairArrayEnumerator : IEnumerator<BroadphasePair>
 	{
-		private int _i = -1;
+		private int _i;
 		private readonly int _count;
 		private readonly AlignedBroadphasePairArray _array;
 
@@ -39,6 +39,7 @@ namespace BulletSharp
 		{
 			_array = array;
 			_count = array.Count;
+			_i = -1;
 		}
 
 		public BroadphasePair Current => _array[_i];
@@ -144,7 +145,12 @@ namespace BulletSharp
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<BroadphasePair> GetEnumerator()
+		public AlignedBroadphasePairArrayEnumerator GetEnumerator()
+		{
+			return new AlignedBroadphasePairArrayEnumerator(this);
+		}
+
+		IEnumerator<BroadphasePair> IEnumerable<BroadphasePair>.GetEnumerator()
 		{
 			return new AlignedBroadphasePairArrayEnumerator(this);
 		}

--- a/BulletSharp/LinearMath/AlignedBroadphasePairArray.cs
+++ b/BulletSharp/LinearMath/AlignedBroadphasePairArray.cs
@@ -57,7 +57,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/LinearMath/AlignedCollisionObjectArray.cs
+++ b/BulletSharp/LinearMath/AlignedCollisionObjectArray.cs
@@ -29,9 +29,9 @@ namespace BulletSharp
 		}
 	}
 
-	public class AlignedCollisionObjectArrayEnumerator : IEnumerator<CollisionObject>
+	public struct AlignedCollisionObjectArrayEnumerator : IEnumerator<CollisionObject>
 	{
-		private int _i = -1;
+		private int _i;
 		private readonly int _count;
 		private readonly IList<CollisionObject> _array;
 
@@ -39,6 +39,7 @@ namespace BulletSharp
 		{
 			_array = array;
 			_count = array.Count;
+			_i = -1;
 		}
 
 		public CollisionObject Current => _array[_i];
@@ -256,7 +257,12 @@ namespace BulletSharp
 			}
 		}
 
-		public IEnumerator<CollisionObject> GetEnumerator()
+		public AlignedCollisionObjectArrayEnumerator GetEnumerator()
+		{
+			return new AlignedCollisionObjectArrayEnumerator(_backingList ?? this as IList<CollisionObject>);
+		}
+
+		IEnumerator<CollisionObject> IEnumerable<CollisionObject>.GetEnumerator()
 		{
 			if (_backingList != null)
 			{

--- a/BulletSharp/LinearMath/AlignedCollisionObjectArray.cs
+++ b/BulletSharp/LinearMath/AlignedCollisionObjectArray.cs
@@ -57,7 +57,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/LinearMath/AlignedIndexedMeshArray.cs
+++ b/BulletSharp/LinearMath/AlignedIndexedMeshArray.cs
@@ -29,7 +29,7 @@ namespace BulletSharp
 		}
 	}
 
-	public class AlignedIndexedMeshArrayEnumerator : IEnumerator<IndexedMesh>
+	public struct AlignedIndexedMeshArrayEnumerator : IEnumerator<IndexedMesh>
 	{
 		private int _i;
 		private readonly int _count;
@@ -154,7 +154,12 @@ namespace BulletSharp
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<IndexedMesh> GetEnumerator()
+		public AlignedIndexedMeshArrayEnumerator GetEnumerator()
+		{
+			return new AlignedIndexedMeshArrayEnumerator(this);
+		}
+
+		IEnumerator<IndexedMesh> IEnumerable<IndexedMesh>.GetEnumerator()
 		{
 			return _backingList.GetEnumerator();
 		}

--- a/BulletSharp/LinearMath/AlignedIndexedMeshArray.cs
+++ b/BulletSharp/LinearMath/AlignedIndexedMeshArray.cs
@@ -58,7 +58,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/LinearMath/AlignedManifoldArray.cs
+++ b/BulletSharp/LinearMath/AlignedManifoldArray.cs
@@ -58,7 +58,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/LinearMath/AlignedManifoldArray.cs
+++ b/BulletSharp/LinearMath/AlignedManifoldArray.cs
@@ -29,7 +29,7 @@ namespace BulletSharp
 		}
 	}
 
-	public class AlignedManifoldArrayEnumerator : IEnumerator<PersistentManifold>
+	public struct AlignedManifoldArrayEnumerator : IEnumerator<PersistentManifold>
 	{
 		private int _i;
 		private readonly int _count;
@@ -144,7 +144,12 @@ namespace BulletSharp
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<PersistentManifold> GetEnumerator()
+		public AlignedManifoldArrayEnumerator GetEnumerator()
+		{
+			return new AlignedManifoldArrayEnumerator(this);
+		}
+
+		IEnumerator<PersistentManifold> IEnumerable<PersistentManifold>.GetEnumerator()
 		{
 			return new AlignedManifoldArrayEnumerator(this);
 		}

--- a/BulletSharp/LinearMath/Collections.cs
+++ b/BulletSharp/LinearMath/Collections.cs
@@ -29,7 +29,7 @@ namespace BulletSharp
 		}
 	};
 
-	public class CompoundShapeChildArrayEnumerator : IEnumerator<CompoundShapeChild>
+	public struct CompoundShapeChildArrayEnumerator : IEnumerator<CompoundShapeChild>
 	{
 		private int _i;
 		private int _count;
@@ -62,7 +62,7 @@ namespace BulletSharp
 		object System.Collections.IEnumerator.Current => _array[_i];
 	}
 
-	public class UIntArrayEnumerator : IEnumerator<uint>
+	public struct UIntArrayEnumerator : IEnumerator<uint>
 	{
 		private int _i;
 		private int _count;
@@ -147,7 +147,12 @@ namespace BulletSharp
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<CompoundShapeChild> GetEnumerator()
+		public CompoundShapeChildArrayEnumerator GetEnumerator()
+		{
+			return new CompoundShapeChildArrayEnumerator(this);
+		}
+
+		IEnumerator<CompoundShapeChild> IEnumerable<CompoundShapeChild>.GetEnumerator()
 		{
 			return new CompoundShapeChildArrayEnumerator(this);
 		}
@@ -228,7 +233,12 @@ namespace BulletSharp
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<uint> GetEnumerator()
+		public UIntArrayEnumerator GetEnumerator()
+		{
+			return new UIntArrayEnumerator(this);
+		}
+
+		IEnumerator<uint> IEnumerable<uint>.GetEnumerator()
 		{
 			return new UIntArrayEnumerator(this);
 		}

--- a/BulletSharp/LinearMath/Collections.cs
+++ b/BulletSharp/LinearMath/Collections.cs
@@ -54,7 +54,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public CompoundShapeChild Current => _array[_i];
@@ -87,7 +87,7 @@ namespace BulletSharp
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public uint Current => _array[_i];

--- a/BulletSharp/Math/Vector3Array.cs
+++ b/BulletSharp/Math/Vector3Array.cs
@@ -26,7 +26,7 @@ namespace BulletSharp.Math
         }
     };
 
-    public class Vector3ArrayEnumerator : IEnumerator<Vector3>
+    public struct Vector3ArrayEnumerator : IEnumerator<Vector3>
     {
         private int _i;
         private readonly int _count;
@@ -127,7 +127,12 @@ namespace BulletSharp.Math
             }
         }
 
-        public IEnumerator<Vector3> GetEnumerator()
+        public Vector3ArrayEnumerator GetEnumerator()
+        {
+            return new Vector3ArrayEnumerator(this);
+        }
+
+        IEnumerator<Vector3> IEnumerable<Vector3>.GetEnumerator()
         {
             return new Vector3ArrayEnumerator(this);
         }

--- a/BulletSharp/Math/Vector3Array.cs
+++ b/BulletSharp/Math/Vector3Array.cs
@@ -51,7 +51,7 @@ namespace BulletSharp.Math
 
         public void Reset()
         {
-            _i = 0;
+            _i = -1;
         }
 
         public Vector3 Current => _array[_i];

--- a/BulletSharp/SoftBody/AlignedAnchorArray.cs
+++ b/BulletSharp/SoftBody/AlignedAnchorArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedAnchorArrayEnumerator : IEnumerator<Anchor>
+	public struct AlignedAnchorArrayEnumerator : IEnumerator<Anchor>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Anchor> GetEnumerator()
+		public AlignedAnchorArrayEnumerator GetEnumerator()
+		{
+			return new AlignedAnchorArrayEnumerator(this);
+		}
+
+		IEnumerator<Anchor> IEnumerable<Anchor>.GetEnumerator()
 		{
 			return new AlignedAnchorArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedAnchorArray.cs
+++ b/BulletSharp/SoftBody/AlignedAnchorArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedClusterArray.cs
+++ b/BulletSharp/SoftBody/AlignedClusterArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedClusterArrayEnumerator : IEnumerator<Cluster>
+	public struct AlignedClusterArrayEnumerator : IEnumerator<Cluster>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Cluster> GetEnumerator()
+		public AlignedClusterArrayEnumerator GetEnumerator()
+		{
+			return new AlignedClusterArrayEnumerator(this);
+		}
+
+		IEnumerator<Cluster> IEnumerable<Cluster>.GetEnumerator()
 		{
 			return new AlignedClusterArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedClusterArray.cs
+++ b/BulletSharp/SoftBody/AlignedClusterArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedFaceArray.cs
+++ b/BulletSharp/SoftBody/AlignedFaceArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedFaceArrayEnumerator : IEnumerator<Face>
+	public struct AlignedFaceArrayEnumerator : IEnumerator<Face>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Face> GetEnumerator()
+		public AlignedFaceArrayEnumerator GetEnumerator()
+		{
+			return new AlignedFaceArrayEnumerator(this);
+		}
+
+		IEnumerator<Face> IEnumerable<Face>.GetEnumerator()
 		{
 			return new AlignedFaceArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedFaceArray.cs
+++ b/BulletSharp/SoftBody/AlignedFaceArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedJointArray.cs
+++ b/BulletSharp/SoftBody/AlignedJointArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedJointArrayEnumerator : IEnumerator<Joint>
+	public struct AlignedJointArrayEnumerator : IEnumerator<Joint>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Joint> GetEnumerator()
+		public AlignedJointArrayEnumerator GetEnumerator()
+		{
+			return new AlignedJointArrayEnumerator(this);
+		}
+
+		IEnumerator<Joint> IEnumerable<Joint>.GetEnumerator()
 		{
 			return new AlignedJointArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedJointArray.cs
+++ b/BulletSharp/SoftBody/AlignedJointArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedLinkArray.cs
+++ b/BulletSharp/SoftBody/AlignedLinkArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedLinkArrayEnumerator : IEnumerator<Link>
+	public struct AlignedLinkArrayEnumerator : IEnumerator<Link>
 	{
 		private int _i;
 		private int _count;
@@ -148,7 +148,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Link> GetEnumerator()
+		public AlignedLinkArrayEnumerator GetEnumerator()
+		{
+			return new AlignedLinkArrayEnumerator(this);
+		}
+
+		IEnumerator<Link> IEnumerable<Link>.GetEnumerator()
 		{
 			return new AlignedLinkArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedLinkArray.cs
+++ b/BulletSharp/SoftBody/AlignedLinkArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedMaterialArray.cs
+++ b/BulletSharp/SoftBody/AlignedMaterialArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedMaterialArrayEnumerator : IEnumerator<Material>
+	public struct AlignedMaterialArrayEnumerator : IEnumerator<Material>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Material> GetEnumerator()
+		public AlignedMaterialArrayEnumerator GetEnumerator()
+		{
+			return new AlignedMaterialArrayEnumerator(this);
+		}
+
+		IEnumerator<Material> IEnumerable<Material>.GetEnumerator()
 		{
 			return new AlignedMaterialArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedMaterialArray.cs
+++ b/BulletSharp/SoftBody/AlignedMaterialArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedNodeArray.cs
+++ b/BulletSharp/SoftBody/AlignedNodeArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedNodeArrayEnumerator : IEnumerator<Node>
+	public struct AlignedNodeArrayEnumerator : IEnumerator<Node>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Node> GetEnumerator()
+		public AlignedNodeArrayEnumerator GetEnumerator()
+		{
+			return new AlignedNodeArrayEnumerator(this);
+		}
+
+		IEnumerator<Node> IEnumerable<Node>.GetEnumerator()
 		{
 			return new AlignedNodeArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedNodeArray.cs
+++ b/BulletSharp/SoftBody/AlignedNodeArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedNoteArray.cs
+++ b/BulletSharp/SoftBody/AlignedNoteArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedNoteArrayEnumerator : IEnumerator<Note>
+	public struct AlignedNoteArrayEnumerator : IEnumerator<Note>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Note> GetEnumerator()
+		public AlignedNoteArrayEnumerator GetEnumerator()
+		{
+			return new AlignedNoteArrayEnumerator(this);
+		}
+
+		IEnumerator<Note> IEnumerable<Note>.GetEnumerator()
 		{
 			return new AlignedNoteArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedSoftBodyArray.cs
+++ b/BulletSharp/SoftBody/AlignedSoftBodyArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedSoftBodyArrayEnumerator : IEnumerator<SoftBody>
+	public struct AlignedSoftBodyArrayEnumerator : IEnumerator<SoftBody>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<SoftBody> GetEnumerator()
+		public AlignedSoftBodyArrayEnumerator GetEnumerator()
+		{
+			return new AlignedSoftBodyArrayEnumerator(this);
+		}
+
+		IEnumerator<SoftBody> IEnumerable<SoftBody>.GetEnumerator()
 		{
 			return new AlignedSoftBodyArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedSoftBodyArray.cs
+++ b/BulletSharp/SoftBody/AlignedSoftBodyArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedTetraArray.cs
+++ b/BulletSharp/SoftBody/AlignedTetraArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedTetraArrayEnumerator : IEnumerator<Tetra>
+	public struct AlignedTetraArrayEnumerator : IEnumerator<Tetra>
 	{
 		private int _i;
 		private int _count;
@@ -131,7 +131,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Tetra> GetEnumerator()
+		public AlignedTetraArrayEnumerator GetEnumerator()
+		{
+			return new AlignedTetraArrayEnumerator(this);
+		}
+
+		IEnumerator<Tetra> IEnumerable<Tetra>.GetEnumerator()
 		{
 			return new AlignedTetraArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedTetraArray.cs
+++ b/BulletSharp/SoftBody/AlignedTetraArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/AlignedTetraScratchArray.cs
+++ b/BulletSharp/SoftBody/AlignedTetraScratchArray.cs
@@ -30,7 +30,7 @@ namespace BulletSharp.SoftBody
 		}
 	}
 
-	public class AlignedTetraScratchArrayEnumerator : IEnumerator<TetraScratch>
+	public struct AlignedTetraScratchArrayEnumerator : IEnumerator<TetraScratch>
 	{
 		private int _i;
 		private int _count;
@@ -136,7 +136,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<TetraScratch> GetEnumerator()
+		public AlignedTetraScratchArrayEnumerator GetEnumerator()
+		{
+			return new AlignedTetraScratchArrayEnumerator(this);
+		}
+
+		IEnumerator<TetraScratch> IEnumerable<TetraScratch>.GetEnumerator()
 		{
 			return new AlignedTetraScratchArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/AlignedTetraScratchArray.cs
+++ b/BulletSharp/SoftBody/AlignedTetraScratchArray.cs
@@ -59,7 +59,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 	}
 

--- a/BulletSharp/SoftBody/BodyArray.cs
+++ b/BulletSharp/SoftBody/BodyArray.cs
@@ -47,7 +47,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Body> GetEnumerator()
+		public GenericListEnumerator<Body> GetEnumerator()
+		{
+			return new GenericListEnumerator<Body>(this);
+		}
+
+		IEnumerator<Body> IEnumerable<Body>.GetEnumerator()
 		{
 			return new GenericListEnumerator<Body>(this);
 		}

--- a/BulletSharp/SoftBody/Collections.cs
+++ b/BulletSharp/SoftBody/Collections.cs
@@ -4,7 +4,7 @@ using static BulletSharp.UnsafeNativeMethods;
 
 namespace BulletSharp.SoftBody
 {
-	public class NodePtrArrayEnumerator : IEnumerator<Node>
+	public struct NodePtrArrayEnumerator : IEnumerator<Node>
 	{
 		private int _i;
 		private int _count;
@@ -75,7 +75,12 @@ namespace BulletSharp.SoftBody
 			throw new NotImplementedException();
 		}
 
-		public IEnumerator<Node> GetEnumerator()
+		public NodePtrArrayEnumerator GetEnumerator()
+		{
+			return new NodePtrArrayEnumerator(this);
+		}
+
+		IEnumerator<Node> IEnumerable<Node>.GetEnumerator()
 		{
 			return new NodePtrArrayEnumerator(this);
 		}

--- a/BulletSharp/SoftBody/Collections.cs
+++ b/BulletSharp/SoftBody/Collections.cs
@@ -29,7 +29,7 @@ namespace BulletSharp.SoftBody
 
 		public void Reset()
 		{
-			_i = 0;
+			_i = -1;
 		}
 
 		public Node Current => _array[_i];


### PR DESCRIPTION
**Changes**
1. Fix all enumerators `Reset` to the correct index.
2. Change all enumerators to struct so there's no object allocation when the concrete classes are used in a foreach loop.